### PR TITLE
fix error in ggez when building invalid meshes

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -20,6 +20,8 @@ impl Painter {
 
 		// drawing meshes
 		for egui::ClippedMesh(_clip_rect, egui_mesh) in self.paint_jobs.borrow_mut().as_slice() {
+            if egui_mesh.vertices.len() < 3 { continue }
+
 			let vertices = egui_mesh.vertices.iter().map(|v| {
 				graphics::Vertex {
 					pos: [v.pos.x, v.pos.y],


### PR DESCRIPTION
In some cases egui may generate meshes with no vertices (e.g. when displaying an empty TextEdit element). Since ggez cant handle meshes with less than 3 vertices an Error is thrown. I suggest to simply filter out meshes with less than 3 vertices before handing them over to ggez.