### PR TITLE
Expose egui version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ use std::{cell::RefCell, ops::Deref, rc::Rc};
 use ggez::graphics::{self, Drawable};
 use egui::{ClippedMesh, CtxRef};
 
+pub use egui;
+
 /// Contains a copy of [`CtxRef`] and a mutable reference for the paint_jobs vector from [`Painter`].
 ///
 /// When is droped automatically will call [`CtxRef::end_frame`] function and update the paint_jobs


### PR DESCRIPTION
This PR exposes the underlying `egui` used so that there is no discrepancy between the version that ggez-egui uses and the one the user uses. This also makes it easier to use as the user doesn't have to worry about including `egui` as well as `ggez-egui` in `Cargo.toml`, just the latter one.